### PR TITLE
OSSM-1421: Fixed leaking BIGNUMs

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -127,8 +127,8 @@ def _rules_proto_repositories():
         urls = ["https://github.com/bazelbuild/rules_proto/archive/" + RULES_PROTO_COMMIT + ".tar.gz"],
     )
 
-ZLIB_RELEASE = "1.2.11"
-ZLIB_SHA256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+ZLIB_RELEASE = "1.2.12"
+ZLIB_SHA256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 
 def _zlib_repositories():
     http_archive(


### PR DESCRIPTION
In `createEcKeyFromJwkEC()` the two `BIGNUM` objects were leaking because `EC_KEY_set_public_key_affine_coordinates()` does _not_ take ownership of them. They would also leak in either of the error cases.

In `createRsaFromJwk()` the two `BIGNUM` objects would leak in either of the error cases. Note that `RSA_set0_key()` _does_ however take ownership of the two `BIGNUM` objects.